### PR TITLE
Fix disable alarm

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,13 +9,16 @@ buildscript {
 apply plugin: 'com.android.application'
 
 dependencies {
-    compile project(':libraries:ShowcaseView')
+    compile (project(':externals:ShowcaseView:library')) {
+      exclude module: 'support-v4'
+      exclude module: 'support-annotations'
+    }
     compile project(':externals:android-preferences')
     compile fileTree(include: '*.jar', dir: 'libs')
 }
 
 android {
-    compileSdkVersion 19
+    compileSdkVersion 23
     buildToolsVersion "24.0.0"
 
     sourceSets {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-include ':externals:ShowcaseView'
+include ':externals:ShowcaseView:library'
 include ':externals:android-preferences'

--- a/src/com/firebirdberlin/nightdream/AlarmClock.java
+++ b/src/com/firebirdberlin/nightdream/AlarmClock.java
@@ -369,6 +369,9 @@ public class AlarmClock extends View {
     private static PendingIntent getPendingAlarmIntent(Context context) {
         Intent intent = new Intent("com.firebirdberlin.nightdream.WAKEUP");
         intent.putExtra("cmd", "start alarm");
-        return PendingIntent.getBroadcast( context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+        //return PendingIntent.getBroadcast( context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+        // PendingIntent.FLAG_CANCEL_CURRENT seems to confuse AlarmManager.cancel() on certain Android devices, e.g. HTC One m7,
+        // i.e. getNextSystemAlarmTime() still returns already cancelled alarm times afterwards.
+        return PendingIntent.getBroadcast( context, 0, intent, 0);
     }
 }

--- a/src/com/firebirdberlin/nightdream/ui/NightDreamUI.java
+++ b/src/com/firebirdberlin/nightdream/ui/NightDreamUI.java
@@ -293,6 +293,7 @@ public class NightDreamUI {
 
     private void setupAlarmClock() {
         if ( ! settings.useInternalAlarm ) {
+            alarmClock.removeAlarm(); //remove any internal alarms first
             String nextAlarm = alarmClock.getNextSystemAlarmTime();
 
             if ( Build.VERSION.SDK_INT >= 19
@@ -303,7 +304,6 @@ public class NightDreamUI {
             alarmTime.setText(nextAlarm);
             alarmTime.setOnClickListener(onStockAlarmTimeClickListener);
             alarmTime.setClickable(true);
-            alarmClock.removeAlarm();
         } else {
             alarmTime.setOnClickListener(null);
             alarmTime.setClickable(false);


### PR DESCRIPTION
Found on SO that PendingIntent.FLAG_CANCEL_CURRENT confuses AlarmManager.cancel() on certain Android devices, e.g. HTC One m7, i.e. getNextSystemAlarmTime() still returns already cancelled alarm times afterwards. Replacing it with 0 seems to fix it.
Moreover I fixed some display update issues when disabling internal alarm in the settings.