### PR TITLE
added country selector to radio stream search

### DIFF
--- a/res/layout/radio_stream_dialog.xml
+++ b/res/layout/radio_stream_dialog.xml
@@ -39,6 +39,12 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_centerHorizontal="true" />
+
+    <Spinner
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/countrySpinner" />
+
     <ListView
         android:id="@+id/radio_stream_list_view"
         android:layout_width="match_parent"

--- a/src/com/firebirdberlin/radiostreamapi/CountryRequestTask.java
+++ b/src/com/firebirdberlin/radiostreamapi/CountryRequestTask.java
@@ -1,0 +1,34 @@
+package com.firebirdberlin.radiostreamapi;
+
+import android.content.Context;
+import android.os.AsyncTask;
+
+import com.firebirdberlin.radiostreamapi.models.Country;
+
+import java.util.List;
+
+public class CountryRequestTask extends AsyncTask<Void, Void, List<Country> > {
+
+    public interface AsyncResponse {
+        public void onCountryRequestFinished(List<Country> countries);
+    }
+
+    private CountryRequestTask.AsyncResponse delegate = null;
+    private Context context;
+
+    public CountryRequestTask(CountryRequestTask.AsyncResponse listener, Context context) {
+        this.delegate = listener;
+        this.context = context;
+    }
+
+    @Override
+    protected List<Country> doInBackground(Void... params) {
+        return DirbleApi.fetchCountries(context.getCacheDir());
+    }
+
+    @Override
+    protected void onPostExecute(List<Country> countries) {
+        delegate.onCountryRequestFinished(countries);
+    }
+
+}

--- a/src/com/firebirdberlin/radiostreamapi/DirbleApi.java
+++ b/src/com/firebirdberlin/radiostreamapi/DirbleApi.java
@@ -2,8 +2,13 @@ package com.firebirdberlin.radiostreamapi;
 
 import android.util.Log;
 
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.BufferedReader;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.String;
 import java.lang.StringBuilder;
@@ -13,18 +18,22 @@ import java.net.SocketTimeoutException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import com.firebirdberlin.radiostreamapi.models.Country;
 import com.firebirdberlin.radiostreamapi.models.RadioStation;
 
 public class DirbleApi {
 
     private static String TAG = "NightDream.DirbleAPI";
     private static String BASEURL = "http://api.dirble.com/v2/search/";
+    private static String COUNTRY_REQUEST_BASE_URL = "http://api.dirble.com/v2/countries/";
     private static String TOKEN = "770f99fe4971232de187503040";
     // mpo: used for developing/testing
     //private static String TOKEN = "ef6dde09a01ea14d9a6d9569b2";
@@ -32,48 +41,23 @@ public class DirbleApi {
     private static int READ_TIMEOUT = 10000;
     private static int CONNECT_TIMEOUT = 10000;
 
-    public static List<RadioStation> fetchStations(String queryString) {
+    private static final String COUNTRIES_CACHE_FILE = "dirbleCountries.json";
+
+    public static List<RadioStation> fetchStations(String queryString, String countryCode) {
         List<RadioStation> stationList = new ArrayList<RadioStation>();
         int responseCode = 0;
         String response = "";
         String responseText = "";
 
-
-//get request
-        /*
-        String urlstring = BASEURL + queryString +
-                "?token=" + TOKEN +
-                "&per_page=" + String.valueOf(MAX_NUM_RESULTS);
-        Log.i(TAG, "requesting " + urlstring);
-        try {
-            URL url = new URL(urlstring);
-            HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
-            urlConnection.setConnectTimeout(CONNECT_TIMEOUT);
-            urlConnection.setReadTimeout(READ_TIMEOUT);
-            response = urlConnection.getResponseMessage();
-            responseCode = urlConnection.getResponseCode();
-            if ( responseCode == 200 ) {
-                responseText = getResponseText(urlConnection);
-            }
-            urlConnection.disconnect();
-        }
-        catch (SocketTimeoutException e) {
-            Log.e(TAG, "Http Timeout");
-            return stationList;
-        }
-        catch (Exception e) {
-            Log.e(TAG, Log.getStackTraceString(e));
-            e.printStackTrace();
-        }
-        */
-
-        //post request
         try {
             String urlstring = BASEURL + "?token=" + TOKEN + "&per_page=" + String.valueOf(MAX_NUM_RESULTS);
             URL url = new URL(urlstring);
             // this should escape the queryString properly and guarantee a valid json string
             JSONObject jsonObject = new JSONObject();
             jsonObject.put("query", queryString);
+            if (countryCode != null && !countryCode.isEmpty()) {
+                jsonObject.put("country", countryCode);
+            }
             String postDataString = jsonObject.toString();
             byte[] postDataBytes = postDataString.getBytes(Charset.forName("UTF-8"));
             int postDataLength = postDataBytes.length;
@@ -91,7 +75,7 @@ public class DirbleApi {
             response = urlConnection.getResponseMessage();
             responseCode = urlConnection.getResponseCode();
             if ( responseCode == 200 ) {
-                responseText = getResponseText(urlConnection);
+                responseText = getResponseText(urlConnection.getInputStream());
             }
             urlConnection.disconnect();
         }
@@ -135,8 +119,97 @@ public class DirbleApi {
         return stationList;
     }
 
-    private static String getResponseText(HttpURLConnection c) throws IOException {
-        BufferedReader br = new BufferedReader(new InputStreamReader(c.getInputStream()));
+
+    public static List<Country> fetchCountries(File cacheDir) {
+
+        List<Country> countries;
+        int responseCode = 0;
+        String response = "";
+        String responseText = "";
+
+        // first try to read from cache
+        try {
+            countries = readCountriesFromCache(cacheDir);
+            if (countries != null && countries.size() > 0) {
+                Log.i(TAG, "read countries from cache");
+                return countries;
+            }
+        } catch (Throwable t) {
+            Log.e(TAG, "error reading countries from cache: " + t.getMessage());
+        }
+        countries = new ArrayList<Country>();
+
+        String urlstring = COUNTRY_REQUEST_BASE_URL + "?token=" + TOKEN;
+        Log.i(TAG, "requesting " + urlstring);
+        try {
+            URL url = new URL(urlstring);
+            HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
+            urlConnection.setConnectTimeout(CONNECT_TIMEOUT);
+            urlConnection.setReadTimeout(READ_TIMEOUT);
+            response = urlConnection.getResponseMessage();
+            responseCode = urlConnection.getResponseCode();
+            if ( responseCode == 200 ) {
+                responseText = getResponseText(urlConnection.getInputStream());
+            }
+            urlConnection.disconnect();
+        }
+        catch (SocketTimeoutException e) {
+            Log.e(TAG, "Http Timeout");
+            return countries;
+        }
+        catch (Exception e) {
+            Log.e(TAG, Log.getStackTraceString(e));
+            e.printStackTrace();
+        }
+
+        Log.i(TAG, " >> response " + response);
+        if (responseCode == 200) {
+            Log.i(TAG, " >> responseText " + responseText);
+            try {
+                countries = decodeCountriesJsonResponse(responseText);
+
+                if (countries.size() > 0) {
+                    // retrieved countries successfully, thus save it to cache (just the response text)
+                    try {
+                        writeCountryResponseToCache(responseText, cacheDir);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                        //TODO
+                        // 1. no caching possible for some reason, so disable fetchCountries at all to save api requests
+                        // 2. fall back to a static list of countries provided within the app to save api requests
+                    }
+                }
+            } catch (JSONException e) {
+                e.printStackTrace();
+                //TODO resilience (count errors and if error threshold is reached (API service broken), disable fetchCountries for some time to save api requests)
+            }
+
+        } else {
+            Log.w(TAG, " >> responseCode " + String.valueOf(responseCode));
+        }
+        return countries;
+    }
+
+    private static List<Country> decodeCountriesJsonResponse(String responseText) throws JSONException {
+        List<Country> countries = new ArrayList<Country>();
+
+        JSONArray jsonArray = new JSONArray(responseText);
+        for (int i = 0; i < jsonArray.length(); i++) {
+            JSONObject jsonCountry = jsonArray.getJSONObject(i);
+
+            Country country = new Country();
+            country.name = jsonCountry.getString("name");
+            country.countryCode = jsonCountry.getString("country_code");
+            country.region = jsonCountry.getString("region");
+            country.subRegion = jsonCountry.getString("subregion");
+            countries.add(country);
+        }
+
+        return countries;
+    }
+
+    private static String getResponseText(InputStream inputStream) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(inputStream));
         StringBuilder sb = new StringBuilder();
         String line;
         while ((line = br.readLine()) != null) {
@@ -144,5 +217,82 @@ public class DirbleApi {
         }
         br.close();
         return sb.toString();
+    }
+
+    private static File getCountryCacheFile(File cacheDir) {
+        return new File(cacheDir, COUNTRIES_CACHE_FILE);
+    }
+
+    private static Date getCacheExpireDate() {
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.MONTH, -1);
+        //cal.add(Calendar.SECOND, -30);
+        Date result = cal.getTime();
+        return result;
+    }
+
+    private static List<Country> readCountriesFromCache(File cacheDir) throws JSONException {
+
+        String responseText = readCountryResponseFromCache(cacheDir);
+        if (responseText != null) {
+            List<Country> countries = decodeCountriesJsonResponse(responseText);
+            return countries;
+        }
+        return null;
+    }
+
+    private static String readCountryResponseFromCache(File cacheDir){
+        File cacheFile = getCountryCacheFile(cacheDir);
+        String response = null;
+
+        if (cacheFile.exists()) {
+
+            // check if cache file expired
+            Date modifiedDate = new Date(cacheFile.lastModified());
+            Date expireDate = getCacheExpireDate();
+            long timeDiff = modifiedDate.getTime() - expireDate.getTime();
+            Log.i(TAG, "cache file will expire in " + timeDiff + " millis");
+            boolean expired = modifiedDate.before(expireDate);
+            if (expired) {
+                Log.i(TAG, "cache file expired");
+                return null;
+            }
+
+            InputStream is = null;
+
+            try {
+                is = new FileInputStream(cacheFile);
+                response = getResponseText(is);
+            } catch (IOException e) {
+                e.printStackTrace();
+            } finally {
+                if (is != null) {
+                    try {
+                        is.close();
+                    } catch (IOException e) {
+                        // nothing to do here
+                    }
+                }
+            }
+        }
+        return response;
+    }
+
+    private static void writeCountryResponseToCache(String responseText, File cacheDir) throws IOException {
+        BufferedWriter out = null;
+        try {
+            File cacheFile = getCountryCacheFile(cacheDir);
+            Log.i(TAG, "write country response to cache file " + cacheFile.getAbsolutePath());
+            //truncates file if already exists
+            out = new BufferedWriter(new FileWriter(cacheFile));
+            out.write(responseText);
+            out.close();
+        } finally {
+            if (out != null) {
+                try {
+                    out.close();
+                } catch (IOException e) {}
+            }
+        }
     }
 }

--- a/src/com/firebirdberlin/radiostreamapi/RadioStreamPreference.java
+++ b/src/com/firebirdberlin/radiostreamapi/RadioStreamPreference.java
@@ -1,7 +1,9 @@
 package com.firebirdberlin.radiostreamapi;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Map;
 
 import android.app.AlertDialog;
 import android.content.Context;
@@ -22,14 +24,16 @@ import android.widget.EditText;
 import android.widget.AdapterView;
 import android.widget.ListView;
 import android.support.v4.widget.ContentLoadingProgressBar;
+import android.widget.Spinner;
 import android.widget.TextView;
 
 import com.firebirdberlin.nightdream.R;
 import com.firebirdberlin.radiostreamapi.StationRequestTask;
+import com.firebirdberlin.radiostreamapi.models.Country;
 import com.firebirdberlin.radiostreamapi.models.RadioStation;
 
 public class RadioStreamPreference extends DialogPreference
-                                   implements StationRequestTask.AsyncResponse {
+                                   implements StationRequestTask.AsyncResponse, CountryRequestTask.AsyncResponse {
     private final static String TAG = "NightDream.RadioStreamPreference";
     private Context mContext = null;
     private EditText queryText = null;
@@ -37,9 +41,11 @@ public class RadioStreamPreference extends DialogPreference
     private ArrayList<RadioStation> stations = new ArrayList<RadioStation>();
     private ArrayAdapter<RadioStation> adapter;
     private ListView stationListView;
+    private Spinner countrySpinner;
     private TextView noResultsText;
     private ContentLoadingProgressBar spinner;
     private Button searchButton;
+    private Map<String, String> countryNameToCodeMap = null;
 
     public RadioStreamPreference(Context ctx) {
         this(ctx, null);
@@ -88,6 +94,7 @@ public class RadioStreamPreference extends DialogPreference
         queryText = ((EditText) v.findViewById(R.id.query_string));
         spinner = (ContentLoadingProgressBar) v.findViewById(R.id.progress_bar);
         stationListView = (ListView) v.findViewById(R.id.radio_stream_list_view);
+        countrySpinner = (Spinner) v.findViewById(R.id.countrySpinner);
         noResultsText = (TextView) v.findViewById(R.id.no_results);
         noResultsText.setVisibility(View.GONE);
 
@@ -142,6 +149,8 @@ public class RadioStreamPreference extends DialogPreference
             }
         });
 
+        initCountrySpinner();
+
         return v;
     }
 
@@ -150,7 +159,8 @@ public class RadioStreamPreference extends DialogPreference
         stationListView.setVisibility(View.GONE);
         noResultsText.setVisibility(View.GONE);
         String query = queryText.getText().toString().trim();
-        new StationRequestTask(this).execute(query);
+        String country = getSelectedCountry();
+        new StationRequestTask(this).execute(query, country);
 
 
         InputMethodManager imm =
@@ -172,6 +182,14 @@ public class RadioStreamPreference extends DialogPreference
     }
 
     @Override
+    public void onCountryRequestFinished(List<Country> countries) {
+        //Log.i(TAG, "found " + countries.size() + " countries.");
+        updateCountryNameToCodeMap(countries);
+        updateCountrySpinner(countries);
+    }
+
+
+    @Override
     protected void onDialogClosed(boolean positiveResult) {
         super.onDialogClosed(positiveResult);
         this.stations.clear();
@@ -186,5 +204,52 @@ public class RadioStreamPreference extends DialogPreference
     protected void onSetInitialValue(boolean restoreValue, Object defaultValue) {
         setTitle(getTitle());
         setSummary(getPersistedString((String) defaultValue));
+    }
+
+    private void initCountrySpinner() {
+        Log.i(TAG, "starting country search");
+        new CountryRequestTask(this, mContext).execute();
+    }
+
+    private void updateCountryNameToCodeMap(List<Country> countries) {
+        countryNameToCodeMap = new HashMap<String, String>();
+        for (Country c : countries) {
+            countryNameToCodeMap.put(c.name, c.countryCode);
+        }
+
+    }
+
+    private void updateCountrySpinner(List<Country> countries) {
+
+        String locale = mContext.getResources().getConfiguration().locale.getCountry();
+
+        int selectionIndex = -1;
+        List<String> countryList = new ArrayList<String>();
+        int i = 0;
+        for (Country c : countries) {
+            countryList.add(c.name);
+            if (selectionIndex == -1 && c.countryCode != null && locale != null && c.countryCode.equals(locale)) {
+                selectionIndex = i;
+            }
+            i++;
+        }
+
+        ArrayAdapter<String> dataAdapter = new ArrayAdapter<String>(mContext, android.R.layout.simple_spinner_item, countryList);
+        dataAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        countrySpinner.setAdapter(dataAdapter);
+        if (selectionIndex > -1) {
+            countrySpinner.setSelection(selectionIndex);
+        }
+    }
+
+    private String getSelectedCountry() {
+        //TODO handle special "any" entry
+        String item = (String)countrySpinner.getSelectedItem();
+        if (item != null) {
+            return countryNameToCodeMap.get(item);
+        } else {
+            return null;
+        }
+
     }
 }

--- a/src/com/firebirdberlin/radiostreamapi/StationRequestTask.java
+++ b/src/com/firebirdberlin/radiostreamapi/StationRequestTask.java
@@ -22,7 +22,8 @@ public class StationRequestTask extends AsyncTask<String, Void, List<RadioStatio
     @Override
     protected List<RadioStation> doInBackground(String... query) {
         String q = query[0];
-        return DirbleApi.fetchStations(q);
+        String country = query.length > 1 ? query[1] : null;
+        return DirbleApi.fetchStations(q, country);
     }
 
     @Override

--- a/src/com/firebirdberlin/radiostreamapi/models/Country.java
+++ b/src/com/firebirdberlin/radiostreamapi/models/Country.java
@@ -1,0 +1,19 @@
+package com.firebirdberlin.radiostreamapi.models;
+
+public class Country {
+
+    public String name;
+    public String countryCode;
+    public String region;
+    public String subRegion;
+
+    @Override
+    public String toString() {
+        return "Country{" +
+                "name='" + name + '\'' +
+                ", countryCode='" + countryCode + '\'' +
+                ", region='" + region + '\'' +
+                ", subRegion='" + subRegion + '\'' +
+                '}';
+    }
+}


### PR DESCRIPTION
This commit adds a country filter to the radio stream search dialog. the countries are fetched from the Dirble API each time the dialog is displayed and cached for 1 month in the local cacheDir.

What's still missing is:
* an "any country" option (which would need localisation)
* search through all stations of the country without a keyword (maybe leave the query input field blank, however this would require the search button)