### PR TITLE
49 search web radio streams without country

### DIFF
--- a/res/layout/radio_stream_dialog.xml
+++ b/res/layout/radio_stream_dialog.xml
@@ -6,6 +6,11 @@
     android:layout_height="wrap_content"
     android:padding="24dp">
 
+    <Spinner
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/countrySpinner" />
+
     <LinearLayout
         android:orientation="horizontal"
         android:layout_width="match_parent"
@@ -40,10 +45,6 @@
         android:layout_height="wrap_content"
         android:layout_centerHorizontal="true" />
 
-    <Spinner
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:id="@+id/countrySpinner" />
 
     <ListView
         android:id="@+id/radio_stream_list_view"

--- a/src/com/firebirdberlin/radiostreamapi/DirbleApi.java
+++ b/src/com/firebirdberlin/radiostreamapi/DirbleApi.java
@@ -34,9 +34,9 @@ public class DirbleApi {
     private static String TAG = "NightDream.DirbleAPI";
     private static String BASEURL = "http://api.dirble.com/v2/search/";
     private static String COUNTRY_REQUEST_BASE_URL = "http://api.dirble.com/v2/countries/";
-    //private static String TOKEN = "770f99fe4971232de187503040";
+    private static String TOKEN = "770f99fe4971232de187503040";
     // mpo: used for developing/testing
-    private static String TOKEN = "ef6dde09a01ea14d9a6d9569b2";
+    //private static String TOKEN = "ef6dde09a01ea14d9a6d9569b2";
     private static int MAX_NUM_RESULTS = 100;
     private static int READ_TIMEOUT = 10000;
     private static int CONNECT_TIMEOUT = 10000;

--- a/src/com/firebirdberlin/radiostreamapi/DirbleApi.java
+++ b/src/com/firebirdberlin/radiostreamapi/DirbleApi.java
@@ -34,9 +34,9 @@ public class DirbleApi {
     private static String TAG = "NightDream.DirbleAPI";
     private static String BASEURL = "http://api.dirble.com/v2/search/";
     private static String COUNTRY_REQUEST_BASE_URL = "http://api.dirble.com/v2/countries/";
-    private static String TOKEN = "770f99fe4971232de187503040";
+    //private static String TOKEN = "770f99fe4971232de187503040";
     // mpo: used for developing/testing
-    //private static String TOKEN = "ef6dde09a01ea14d9a6d9569b2";
+    private static String TOKEN = "ef6dde09a01ea14d9a6d9569b2";
     private static int MAX_NUM_RESULTS = 100;
     private static int READ_TIMEOUT = 10000;
     private static int CONNECT_TIMEOUT = 10000;

--- a/src/com/firebirdberlin/radiostreamapi/RadioStreamPreference.java
+++ b/src/com/firebirdberlin/radiostreamapi/RadioStreamPreference.java
@@ -9,10 +9,12 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.preference.DialogPreference;
+import android.telephony.TelephonyManager;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.view.KeyEvent;
@@ -245,7 +247,7 @@ public class RadioStreamPreference extends DialogPreference
 
     private void updateCountrySpinner(List<Country> countries) {
 
-        String locale = mContext.getResources().getConfiguration().locale.getCountry();
+        String selectedCountryCode = getSelectedCountryCode();
 
         int countryIndexOfCurrentLocale = -1;
         List<String> countryList = new ArrayList<String>();
@@ -287,7 +289,7 @@ public class RadioStreamPreference extends DialogPreference
         int i = 0;
         for (Country c : countries) {
             countryList.add(c.name);
-            if (countryIndexOfCurrentLocale == -1 && c.countryCode != null && locale != null && c.countryCode.equals(locale)) {
+            if (countryIndexOfCurrentLocale == -1 && c.countryCode != null && selectedCountryCode != null && c.countryCode.equals(selectedCountryCode)) {
                 countryIndexOfCurrentLocale = i;
             }
             i++;
@@ -296,12 +298,37 @@ public class RadioStreamPreference extends DialogPreference
         int selectedItemIndex = countryIndexOfCurrentLocale + 1;
 
         ArrayAdapter<String> dataAdapter = new ArrayAdapter<String>(mContext, android.R.layout.simple_spinner_item, countryList);
-        //dataAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        dataAdapter.setDropDownViewResource(android.R.layout.select_dialog_singlechoice);
+
+        dataAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        //dataAdapter.setDropDownViewResource(android.R.layout.select_dialog_singlechoice);
         countrySpinner.setAdapter(dataAdapter);
         if (selectedItemIndex > -1) {
             countrySpinner.setSelection(selectedItemIndex);
         }
+    }
+
+    private String getSelectedCountryCode() {
+
+        String locale = null;
+
+        try {
+            TelephonyManager tm = (TelephonyManager) mContext.getSystemService(Context.TELEPHONY_SERVICE);
+            if (tm != null) {
+                String simCountryCode = tm.getSimCountryIso();
+                if (simCountryCode != null && !simCountryCode.isEmpty()) {
+                    locale = simCountryCode.toUpperCase();
+                }
+                //Log.i(TAG, "iso country code is " + locale);
+            }
+        } catch (Throwable t) {
+
+        }
+
+        if (locale == null) {
+            locale = mContext.getResources().getConfiguration().locale.getCountry();
+        }
+
+        return locale;
     }
 
     private String getSelectedCountry() {

--- a/src/com/firebirdberlin/radiostreamapi/RadioStreamPreference.java
+++ b/src/com/firebirdberlin/radiostreamapi/RadioStreamPreference.java
@@ -1,5 +1,7 @@
 package com.firebirdberlin.radiostreamapi;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ArrayList;
@@ -210,6 +212,20 @@ public class RadioStreamPreference extends DialogPreference
     @Override
     public void onCountryRequestFinished(List<Country> countries) {
         //Log.i(TAG, "found " + countries.size() + " countries.");
+        // sort countries alphabetically
+        Collections.sort(countries, new Comparator<Country>() {
+            @Override
+            public int compare(Country lhs, Country rhs) {
+                if (lhs.name == null) {
+                    return -1;
+                }
+                if (rhs.name == null) {
+                    return 1;
+                }
+                return lhs.name.compareTo(rhs.name);
+            }
+        });
+
         updateCountryNameToCodeMap(countries);
         updateCountrySpinner(countries);
     }


### PR DESCRIPTION
* Put empty entry to top of country list, meaning "all countries"
* Put sim country code and current locale to top of the this, which would be the preferred countries to look for (one if both are equal, otherwise two, e.g. CA and FR)
* restart search if another country is selected
* omit country code in list of found radio stations if a country is selected
* moved country drop-down above search field, so the station result list wont look like belonging to the country drop-down (only a suggestion)