### PR TITLE
added action buttons and radio station title to notification

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -109,6 +109,7 @@ Please preserve the xml tags and the utf8 encoding.
 <string name="minBrightness">min. Bildschirmhelligkeit</string>
 <string name="minute">min</string>
 <string name="mute_ringer">lautlos</string>
+<string name="next">weiter</string>
 <string name="night_mode_activation_auto">automatisch</string>
 <string name="night_mode_activation_manual">manuell</string>
 <string name="night_mode_activation_mode">Aktivierung</string>

--- a/src/com/firebirdberlin/nightdream/Settings.java
+++ b/src/com/firebirdberlin/nightdream/Settings.java
@@ -137,7 +137,6 @@ public class Settings {
     private static FavoriteRadioStations getFavoriteRadioStations(SharedPreferences preferences) {
         String json = preferences.getString(FAVORITE_RADIO_STATIONS_KEY, null);
         if (json != null) {
-            Log.i(TAG, json);
             try {
                 FavoriteRadioStations stations = FavoriteRadioStations.fromJson(json);
                 return stations;

--- a/src/com/firebirdberlin/nightdream/services/RadioStreamService.java
+++ b/src/com/firebirdberlin/nightdream/services/RadioStreamService.java
@@ -260,7 +260,9 @@ public class RadioStreamService extends Service implements MediaPlayer.OnErrorLi
 
     public void setAlarmVolume(int volume, boolean useMusicStream) {
         AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
-
+        if (audioManager == null) {
+            return;
+        }
         currentStreamType =
                 (useMusicStream) ? AudioManager.STREAM_MUSIC : AudioManager.STREAM_ALARM;
 
@@ -385,25 +387,24 @@ public class RadioStreamService extends Service implements MediaPlayer.OnErrorLi
     }
 
     /**
-     * add stop button for normal radio, and for alarm radio preview (stream started in preferences dialog), but not for alarm
+     * add stop button for normal radio, and for alarm radio preview (stream started in
+     * preferences dialog), but not for alarm
      */
-    private void addActionButtonsToNotificationBuilder(NotificationCompat.Builder noteBuilder, Intent intent) {
+    private void addActionButtonsToNotificationBuilder(NotificationCompat.Builder noteBuilder,
+                                                       Intent intent) {
 
         String action = intent.getAction();
-
         boolean hasExtraDebug = intent.getBooleanExtra(EXTRA_DEBUG, false);
 
         if ( ACTION_START_STREAM.equals(action) || (ACTION_START.equals(action) && hasExtraDebug) ) {
             noteBuilder.addAction(notificationStopAction());
 
             // show radio station name in notification
-            String currentStationName = currentRadioStationName(intent);
-            if (currentStationName != null) {
-                noteBuilder.setContentText(currentStationName);
-            }
+            noteBuilder.setContentText(currentRadioStationName(intent));
         }
 
-        // if normal radio is playing and multiple stations are configured, also add button to switch to next station
+        // if normal radio is playing and multiple stations are configured, also add button to
+        // switch to next station
         if ( ACTION_START_STREAM.equals(action) ) {
             FavoriteRadioStations stations = settings.getFavoriteRadioStations();
             if (stations != null && stations.numAvailableStations() > 1)
@@ -420,16 +421,13 @@ public class RadioStreamService extends Service implements MediaPlayer.OnErrorLi
     }
 
     private NotificationCompat.Action notificationAction(String intentAction, String text) {
-
         Intent intent = new Intent(this, RadioStreamService.class);
         intent.setAction(intentAction);
 
         PendingIntent pi = PendingIntent.getService(
                 this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
-        NotificationCompat.Action action =
-                new NotificationCompat.Action.Builder(0, text, pi).build();
-        return action;
+        return new NotificationCompat.Action.Builder(0, text, pi).build();
     }
 
     private String currentRadioStationName(Intent intent) {
@@ -437,9 +435,8 @@ public class RadioStreamService extends Service implements MediaPlayer.OnErrorLi
         RadioStation station = settings.getFavoriteRadioStation(currentIndex);
         if (station != null && station.name != null && !station.name.isEmpty()) {
             return station.name;
-        } else {
-            return null;
         }
+        return "";
     }
 
     private void switchToNextStation() {

--- a/src/com/firebirdberlin/nightdream/services/RadioStreamService.java
+++ b/src/com/firebirdberlin/nightdream/services/RadioStreamService.java
@@ -161,7 +161,7 @@ public class RadioStreamService extends Service implements MediaPlayer.OnErrorLi
         NotificationCompat.Builder noteBuilder = new NotificationCompat.Builder(this)
                 .setContentTitle(getString(R.string.radio))
                 .setSmallIcon(R.drawable.ic_radio)
-                .setPriority(NotificationCompat.PRIORITY_MIN);
+                .setPriority(NotificationCompat.PRIORITY_MAX);
 
         addActionButtonsToNotificationBuilder(noteBuilder, intent);
 
@@ -394,7 +394,6 @@ public class RadioStreamService extends Service implements MediaPlayer.OnErrorLi
         boolean hasExtraDebug = intent.getBooleanExtra(EXTRA_DEBUG, false);
 
         if ( ACTION_START_STREAM.equals(action) || (ACTION_START.equals(action) && hasExtraDebug) ) {
-            noteBuilder.setPriority(NotificationCompat.PRIORITY_MAX);
             noteBuilder.addAction(notificationStopAction());
 
             // show radio station name in notification

--- a/src/com/firebirdberlin/radiostreamapi/models/FavoriteRadioStations.java
+++ b/src/com/firebirdberlin/radiostreamapi/models/FavoriteRadioStations.java
@@ -1,6 +1,5 @@
 package com.firebirdberlin.radiostreamapi.models;
 
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -33,9 +32,8 @@ public class FavoriteRadioStations {
 
     public int numAvailableStations() {
         int total = 0;
-        for (int i = 0; i < radioStations.length; i++) {
-            RadioStation s = (radioStations[i]);
-            if (s != null) {
+        for (RadioStation radioStation : radioStations) {
+            if (radioStation != null) {
                 total++;
             }
         }
@@ -49,7 +47,7 @@ public class FavoriteRadioStations {
 
         for (int i = 0; i < radioStations.length; i++) {
             int nextIndex = (i + currentIndex + 1) % radioStations.length;
-            RadioStation s = (radioStations[nextIndex]);
+            RadioStation s = radioStations[nextIndex];
             if (s != null) {
                 return nextIndex;
             }
@@ -87,7 +85,7 @@ public class FavoriteRadioStations {
             if (station != null) {
                 try {
                     favorites.put(String.valueOf(i), station.toJsonObject());
-                } catch (JSONException e) {
+                } catch (JSONException ignored) {
                 }
             }
         }

--- a/src/com/firebirdberlin/radiostreamapi/models/FavoriteRadioStations.java
+++ b/src/com/firebirdberlin/radiostreamapi/models/FavoriteRadioStations.java
@@ -31,6 +31,33 @@ public class FavoriteRadioStations {
         return radioStations[index];
     }
 
+    public int numAvailableStations() {
+        int total = 0;
+        for (int i = 0; i < radioStations.length; i++) {
+            RadioStation s = (radioStations[i]);
+            if (s != null) {
+                total++;
+            }
+        }
+        return total;
+    }
+
+    public int nextAvailableIndex(int currentIndex) {
+        if (currentIndex < 0 || currentIndex >= radioStations.length) {
+            return -1;
+        }
+
+        for (int i = 0; i < radioStations.length; i++) {
+            int nextIndex = (i + currentIndex + 1) % radioStations.length;
+            RadioStation s = (radioStations[nextIndex]);
+            if (s != null) {
+                return nextIndex;
+            }
+        }
+        // should never happen
+        return -1;
+    }
+
     private static final String JSON_FAVORITES = "favorites";
 
     public static FavoriteRadioStations fromJson(String json) throws JSONException {


### PR DESCRIPTION
This should solve #122. The notification now contains a "stop" button, and and "next" button if multiple radio stations are configured. the next button simply starts the next available radio preset (rotates after last preset). The name of currently playing station is display as notification text.