### PR TITLE
Try to fix NumberFormatException in PollenExposure

### DIFF
--- a/src/com/firebirdberlin/nightdream/PollenExposure.java
+++ b/src/com/firebirdberlin/nightdream/PollenExposure.java
@@ -1,5 +1,6 @@
 package com.firebirdberlin.nightdream;
 
+import android.text.TextUtils;
 import android.util.Log;
 
 import org.json.JSONArray;
@@ -33,8 +34,13 @@ public class PollenExposure {
     public void parse(String json, String plz) {
         pollenList.clear();
         pollenAreaList.clear();
+        Integer area;
 
-        Integer area = plzToArea(Integer.parseInt(plz.substring(0, 2)));
+        if (!plz.isEmpty() && TextUtils.isDigitsOnly(plz.substring(0, 2))) {
+            area = plzToArea(Integer.parseInt(plz.substring(0, 2)));
+        } else{
+            area = -1;
+        }
 
         if (json != null && area != -1) {
             try {


### PR DESCRIPTION
Typ: java.lang.RuntimeException

java.lang.RuntimeException: 
  at android.os.AsyncTask$4.done (AsyncTask.java:415)
  at java.util.concurrent.FutureTask.finishCompletion (FutureTask.java:383)
  at java.util.concurrent.FutureTask.setException (FutureTask.java:252)
  at java.util.concurrent.FutureTask.run (FutureTask.java:271)
  at android.os.AsyncTask$SerialExecutor$1.run (AsyncTask.java:305)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1167)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:641)
  at java.lang.Thread.run (Thread.java:923)
Caused by: java.lang.NumberFormatException: 
  at java.lang.Integer.parseInt (Integer.java:615)
  at java.lang.Integer.parseInt (Integer.java:650)
  at com.firebirdberlin.nightdream.PollenExposure.parse (Unknown Source:16)
  at com.firebirdberlin.dwd.PollenExposureRequestTask.doInBackground (PollenExposureRequestTask.java)
  at com.firebirdberlin.dwd.PollenExposureRequestTask.doInBackground (PollenExposureRequestTask.java)
  at android.os.AsyncTask$3.call (AsyncTask.java:394)
  at java.util.concurrent.FutureTask.run (FutureTask.java:266)
  at android.os.AsyncTask$SerialExecutor$1.run (AsyncTask.java:305)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1167)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:641)
  at java.lang.Thread.run (Thread.java:923)