### PR TITLE
PowerConnectionReceiver

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -189,6 +189,7 @@
             android:enabled="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
         <receiver

--- a/src/com/firebirdberlin/nightdream/receivers/PowerConnectionReceiver.java
+++ b/src/com/firebirdberlin/nightdream/receivers/PowerConnectionReceiver.java
@@ -29,7 +29,7 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 
 public class PowerConnectionReceiver extends BroadcastReceiver {
-    private static String TAG = "NightDream.PowerConnectionReceiver";
+    private static final String TAG = "NightDream:PwrConnecRvr";
     private static int PENDING_INTENT_START_APP = 0;
 
     public static PowerConnectionReceiver register(Context ctx) {


### PR DESCRIPTION
fixed: tag name should use a unique prefix followed by a colon
add intent-filter: android.intent.action.LOCKED_BOOT_COMPLETED -> https://developer.android.com/training/articles/direct-boot