### PR TITLE
Try to fix ClassCastException in notification

### DIFF
--- a/src/com/firebirdberlin/nightdream/NotificationList/Notification.java
+++ b/src/com/firebirdberlin/nightdream/NotificationList/Notification.java
@@ -68,7 +68,7 @@ public class Notification implements Parcelable {
         text = in.readString();
         textBig = in.readString();
         summaryText = in.readString();
-        remoteView = getParcelable(in, RemoteViews.class.getClassLoader());
+        remoteView = getParcelable(in, null);
         bitmapLargeIcon = getParcelable(in, Bitmap.class.getClassLoader());
         title = in.readString();
         titleBig = in.readString();

--- a/src/com/firebirdberlin/nightdream/NotificationList/NotificationRecyclerViewAdapter.java
+++ b/src/com/firebirdberlin/nightdream/NotificationList/NotificationRecyclerViewAdapter.java
@@ -168,17 +168,19 @@ public class NotificationRecyclerViewAdapter extends RecyclerView.Adapter<Notifi
 
         switch (match) {
             case "DecoratedCustomViewStyle":
-                try {
-                    if (notification.getBigCardView().getParent() != null) {
-                        ((ViewGroup) notification.getBigCardView().getParent()).removeView(notification.getBigCardView()); // <- fix
+                if (notification.getBigCardView() != null) {
+                    try {
+                        if (notification.getBigCardView().getParent() != null) {
+                            ((ViewGroup) notification.getBigCardView().getParent()).removeView(notification.getBigCardView()); // <- fix
+                        }
+                        holder.notificationRemoteView.removeAllViews();
+                        holder.itemView.findViewById(R.id.notify).setVisibility(View.GONE);
+                        if (holder.notificationRemoteView.getChildCount() == 0) {
+                            holder.notificationRemoteView.addView(notification.getBigCardView());
+                        }
+                    } catch (Exception ex) {
+                        Log.e(TAG, "DecoratedCustomViewStyle", ex);
                     }
-                    holder.notificationRemoteView.removeAllViews();
-                    holder.itemView.findViewById(R.id.notify).setVisibility(View.GONE);
-                    if (holder.notificationRemoteView.getChildCount() == 0) {
-                        holder.notificationRemoteView.addView(notification.getBigCardView());
-                    }
-                } catch (Exception ex) {
-                    Log.e(TAG, "DecoratedCustomViewStyle", ex);
                 }
                 break;
             case "InboxStyle":


### PR DESCRIPTION
java.lang.ClassCastException: 
  at android.widget.RemoteViews$ViewGroupActionRemove.apply (RemoteViews.java:1791)
  at android.widget.RemoteViews.performApply (RemoteViews.java:3887)
  at android.widget.RemoteViews.apply (RemoteViews.java:3612)
  at android.widget.RemoteViews.apply (RemoteViews.java:3604)
  at com.firebirdberlin.nightdream.NotificationList.Notification.<init> (Notification.java:260)
  at com.firebirdberlin.nightdream.mNotificationListener.listNotifications (mNotificationListener.java:110)
  at com.firebirdberlin.nightdream.mNotificationListener.onNotificationRemoved (mNotificationListener.java:3)
  at android.service.notification.NotificationListenerService.onNotificationRemoved (NotificationListenerService.java:392)
  at android.service.notification.NotificationListenerService.onNotificationRemoved (NotificationListenerService.java:418)
  at android.service.notification.NotificationListenerService.onNotificationRemoved (NotificationListenerService.java:431)
  at android.service.notification.NotificationListenerService$MyHandler.handleMessage (NotificationListenerService.java:2072)
  at android.os.Handler.dispatchMessage (Handler.java:107)
  at android.os.Looper.loop (Looper.java:237)
  at android.app.ActivityThread.main (ActivityThread.java:8034)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:493)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1076)