### PR TITLE
Fix alarm tone for alarms set by swipe gesture (resolves #284)

### DIFF
--- a/src/com/firebirdberlin/nightdream/Settings.java
+++ b/src/com/firebirdberlin/nightdream/Settings.java
@@ -273,7 +273,7 @@ public class Settings {
         return preferences.getInt("lastActiveRadioStation", -1);
     }
 
-    static String getDefaultAlarmTone(Context context) {
+    public static String getDefaultAlarmTone(Context context) {
         SharedPreferences preferences = getDefaultSharedPreferences(context);
         if (preferences == null) {
             return null;

--- a/src/com/firebirdberlin/nightdream/ui/AlarmClockLayout.java
+++ b/src/com/firebirdberlin/nightdream/ui/AlarmClockLayout.java
@@ -350,7 +350,13 @@ public class AlarmClockLayout extends LinearLayout {
             String displayName = "alarm tone";
             try {
                 if (Utility.isEmpty(alarmClockEntry.soundUri)) {
-                    Uri soundUri = Uri.parse(Settings.getDefaultAlarmTone(context));
+                    Uri soundUri;
+                    String tone = Settings.getDefaultAlarmTone(context);
+                    if (Utility.isEmpty(tone)) {
+                        soundUri = Utility.getDefaultAlarmToneUri();
+                    } else {
+                        soundUri = Uri.parse(tone);
+                    }
                     displayName = Utility.getSoundFileTitleFromUri(context, soundUri);
                 } else {
                     displayName = Utility.getSoundFileTitleFromUri(context, alarmClockEntry.soundUri);

--- a/src/com/firebirdberlin/nightdream/ui/AlarmClockLayout.java
+++ b/src/com/firebirdberlin/nightdream/ui/AlarmClockLayout.java
@@ -31,6 +31,7 @@ import androidx.fragment.app.FragmentManager;
 import com.firebirdberlin.nightdream.BillingHelperActivity;
 import com.firebirdberlin.nightdream.R;
 import com.firebirdberlin.nightdream.SetAlarmClockActivity;
+import com.firebirdberlin.nightdream.Settings;
 import com.firebirdberlin.nightdream.Utility;
 import com.firebirdberlin.nightdream.models.SimpleTime;
 import com.firebirdberlin.nightdream.repositories.VibrationHandler;
@@ -349,7 +350,7 @@ public class AlarmClockLayout extends LinearLayout {
             String displayName = "alarm tone";
             try {
                 if (Utility.isEmpty(alarmClockEntry.soundUri)) {
-                    Uri soundUri = Utility.getDefaultAlarmToneUri();
+                    Uri soundUri = Uri.parse(Settings.getDefaultAlarmTone(context));
                     displayName = Utility.getSoundFileTitleFromUri(context, soundUri);
                 } else {
                     displayName = Utility.getSoundFileTitleFromUri(context, alarmClockEntry.soundUri);


### PR DESCRIPTION
Instead of using the android standard alarm tone, now the last alarm tone selected in the app is used.