### PR TITLE
ChargingStateChangeReceiver

### DIFF
--- a/src/com/firebirdberlin/nightdream/receivers/ChargingStateChangeReceiver.java
+++ b/src/com/firebirdberlin/nightdream/receivers/ChargingStateChangeReceiver.java
@@ -26,9 +26,12 @@ public class ChargingStateChangeReceiver extends BroadcastReceiver {
             ctx.unregisterReceiver(receiver);
         }
     }
+    
     @Override
     public void onReceive(Context context, Intent intent) {
-        getAndSaveBatteryReference(context.getApplicationContext());
+        if (intent.getAction().equals(Intent.ACTION_BOOT_COMPLETED)){
+                getAndSaveBatteryReference(context.getApplicationContext());
+        }
     }
 
     public static BatteryValue getAndSaveBatteryReference(Context context) {


### PR DESCRIPTION
Fix for:

This broadcast receiver declares an intent-filter for a protected broadcast action string, which can only be sent by the system, not third-party applications. However, the receiver's onReceive method does not appear to call getAction to ensure that the received Intent's action string matches the expected value, potentially making it possible for another actor to send a spoofed intent with no action string or a different action string and cause undesired behavior.