### PR TITLE
notification bugfix

### DIFF
--- a/src/com/firebirdberlin/nightdream/NightDreamActivity.java
+++ b/src/com/firebirdberlin/nightdream/NightDreamActivity.java
@@ -509,9 +509,11 @@ public class NightDreamActivity extends BillingHelperActivity
         clockLayoutContainer.post(() -> {
             // ask for active notifications
             if (Build.VERSION.SDK_INT >= 18) {
-                Intent i = new Intent(Config.ACTION_NOTIFICATION_LISTENER);
-                i.putExtra("command", "list");
-                LocalBroadcastManager.getInstance(context).sendBroadcast(i);
+                if (Settings.showNotification(this)) {
+                    Intent i = new Intent(Config.ACTION_NOTIFICATION_LISTENER);
+                    i.putExtra("command", "list");
+                    LocalBroadcastManager.getInstance(context).sendBroadcast(i);
+                }
             }
         });
 

--- a/src/com/firebirdberlin/nightdream/NotificationList/Notification.java
+++ b/src/com/firebirdberlin/nightdream/NotificationList/Notification.java
@@ -60,18 +60,18 @@ public class Notification implements Parcelable {
 
     @RequiresApi(api = Build.VERSION_CODES.KITKAT)
     protected Notification(Parcel in) {
-        bigPicture = getParcelable(in, Bitmap.class.getClassLoader());
+        bigPicture = (Bitmap) getParcelable(in, Bitmap.class.getClassLoader());
         time = in.readString();
         postTimestamp = in.readLong();
         applicationName = in.readString();
         text = in.readString();
         textBig = in.readString();
         summaryText = in.readString();
-        bitmapLargeIcon = getParcelable(in, Bitmap.class.getClassLoader());
+        bitmapLargeIcon = (Bitmap) getParcelable(in, Bitmap.class.getClassLoader());
         title = in.readString();
         titleBig = in.readString();
         template = in.readString();
-        pendingIntent = getParcelable(in, PendingIntent.class.getClassLoader());
+        pendingIntent = (PendingIntent) getParcelable(in, PendingIntent.class.getClassLoader());
         actions = in.createTypedArray(android.app.Notification.Action.CREATOR);
         packageName = in.readString();
         isClearable = in.readByte() != 0;
@@ -135,7 +135,7 @@ public class Notification implements Parcelable {
         return null;
     }
 
-    <T> T getParcelable(Parcel in, ClassLoader classLoader) {
+    Parcelable getParcelable(Parcel in, ClassLoader classLoader) {
         try {
             return in.readParcelable(classLoader);
         } catch (ClassCastException ignored) {

--- a/src/com/firebirdberlin/nightdream/ui/NightDreamUI.java
+++ b/src/com/firebirdberlin/nightdream/ui/NightDreamUI.java
@@ -584,6 +584,7 @@ public class NightDreamUI {
         mainFrame.post(this::configureSafeRect);
 
         settings.reload();
+        notificationStatusBar.removeAllViews();
         notificationStatusBar.setClickable(Settings.useNotificationStatusBar(mContext));
 
         vibrantColor = 0;


### PR DESCRIPTION
NightDreamActivity: clockLayoutContainer.post ask for active notifications only if Settings.showNotification
NightDreamUI: notificationStatusBar.removeAllViews() if Settings.showNotification switched to false
Notification: changed "<T> T getParcelable(Parcel in, ClassLoader classLoader)" to "Parcelable getParcelable(Parcel in, ClassLoader classLoader)"