### PR TITLE
ImageDecoder for Android 9+

### DIFF
--- a/src/com/firebirdberlin/nightdream/Utility.java
+++ b/src/com/firebirdberlin/nightdream/Utility.java
@@ -22,6 +22,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.graphics.Bitmap;
 import android.graphics.Color;
+import android.graphics.ImageDecoder;
 import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.Point;
@@ -870,6 +871,17 @@ public class Utility {
     public static int getCameraPhotoOrientation(FileDescriptor fileDescriptor) {
         try {
             ExifInterface exif = new ExifInterface(fileDescriptor);
+            return getCameraPhotoOrientation(exif);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+
+    public static int getCameraPhotoOrientation(Context context, Uri  fileDescriptor) {
+        Log.d(TAG, "getCameraPhotoOrientation(Context context, Uri  fileDescriptor)");
+        try {
+            ExifInterface exif = new ExifInterface(context.getContentResolver().openInputStream(fileDescriptor));
             return getCameraPhotoOrientation(exif);
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
Imagedecoder to load images (Android 9+)
Imagedecoder for gif (Android 12+)

-----
In Android 12, the NDK ImageDecoder API has been expanded to decode all frames and timing data from images that use the animated GIF and animated WebP file formats. When it was introduced in Android 11, this API decoded only the first image from animations in these formats.

Use ImageDecoder instead of third-party libraries to further decrease APK size and benefit from future updates related to security and performance.

https://developer.android.com/ndk/reference/group/image-decoder