### PR TITLE
StopServiceReceiver

### DIFF
--- a/src/com/firebirdberlin/nightdream/receivers/StopServiceReceiver.java
+++ b/src/com/firebirdberlin/nightdream/receivers/StopServiceReceiver.java
@@ -3,6 +3,7 @@ package com.firebirdberlin.nightdream.receivers;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.util.Log;
 
 import com.firebirdberlin.nightdream.Config;
@@ -16,8 +17,10 @@ public class StopServiceReceiver extends BroadcastReceiver {
         if (action == null) return;
         Log.i("StopServiceReceiver", action + " received!");
 
-        Intent it = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
-        context.sendBroadcast(it);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            Intent it = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
+            context.sendBroadcast(it);
+        }
 
         NightDreamActivity.start(context, Config.ACTION_STOP_BACKGROUND_SERVICE);
     }


### PR DESCRIPTION
If your app targets Android 12, you don't need to use ACTION_CLOSE_SYSTEM_DIALOGS in this situation. That's because, if your app calls startActivity() while a window is on top of the notification drawer, the system closes the notification drawer automatically.

https://developer.android.com/about/versions/12/behavior-changes-all?msclkid=3ad37f25cf7411ecb536010741f51e42#user_experience