### PR TITLE
RSSViewModel: Fixed NullPointerException 

### DIFF
--- a/src/com/firebirdberlin/nightdream/viewmodels/RSSViewModel.java
+++ b/src/com/firebirdberlin/nightdream/viewmodels/RSSViewModel.java
@@ -35,7 +35,9 @@ public class RSSViewModel extends ViewModel {
 
     public static void stopWorker() {
         Log.d(TAG, "stopWorker");
-        WorkManager.getInstance(weakContext.get()).cancelAllWorkByTag(TAG);
+        if (weakContext.get() != null) {
+            WorkManager.getInstance(weakContext.get()).cancelAllWorkByTag(TAG);
+        }
     }
 
     public static void setTickerSpeed(Long speed) {


### PR DESCRIPTION
java.lang.NullPointerException

Exception java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Object java.lang.ref.Reference.get()' on a null object reference
 at com.firebirdberlin.nightdream.viewmodels.RSSViewModel.stopWorker (RSSViewModel.java)