### PR TITLE
AlarmClockView Bugfix

### DIFF
--- a/src/com/firebirdberlin/nightdream/ui/AlarmClockView.java
+++ b/src/com/firebirdberlin/nightdream/ui/AlarmClockView.java
@@ -518,6 +518,8 @@ public class AlarmClockView extends View {
 
         void setRadius(int radius) {
             if (radius == this.radius) return;
+            if (radius < 100) radius = 100;
+
             this.radius = radius;
             this.radius2 = (int) (0.93 * radius);
             this.radius3 = (int) (0.86 * radius);


### PR DESCRIPTION
java.lang.IllegalArgumentException

Exception java.lang.IllegalArgumentException: width and height must be > 0
  at android.graphics.Bitmap.createBitmap (Bitmap.java:1113)
  at android.graphics.Bitmap.createBitmap (Bitmap.java:952)
  at android.graphics.Bitmap.createScaledBitmap (Bitmap.java:807)
  at com.firebirdberlin.nightdream.ui.AlarmClockView$HotCorner.setRadius (AlarmClockView.java)
  at com.firebirdberlin.nightdream.ui.AlarmClockView.onDraw (AlarmClockView.java:71)