### PR TITLE
BatteryReferenceViewModel Bugfix NullPointerException

### DIFF
--- a/src/com/firebirdberlin/nightdream/viewmodels/BatteryReferenceViewModel.java
+++ b/src/com/firebirdberlin/nightdream/viewmodels/BatteryReferenceViewModel.java
@@ -50,7 +50,12 @@ public class BatteryReferenceViewModel extends ViewModel {
     }
 
     public static BatteryValue getValue() {
-        return batteryValue.getValue();
+        if (batteryValue == null){
+            return null;
+        }
+        else {
+            return batteryValue.getValue();
+        }
     }
 
     public static void observe(Context context, @NonNull Observer<BatteryValue> observer) {


### PR DESCRIPTION
Bugfix for:

java.util.concurrent.ExecutionException: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Object androidx.lifecycle.MutableLiveData.getValue()' on a null object reference
                                                                                                    	at androidx.work.impl.utils.futures.AbstractFuture.getDoneValue(AbstractFuture.java:516)
                                                                                                    	at androidx.work.impl.utils.futures.AbstractFuture.get(AbstractFuture.java:475)
                                                                                                    	at androidx.work.impl.WorkerWrapper$2.run(WorkerWrapper.java:311)
                                                                                                    	at androidx.work.impl.utils.SerialExecutor$Task.run(SerialExecutor.java:91)
                                                                                                    	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
                                                                                                    	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
                                                                                                    	at java.lang.Thread.run(Thread.java:1012)
                                                                                                    Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Object androidx.lifecycle.MutableLiveData.getValue()' on a null object reference
                                                                                                    	at com.firebirdberlin.nightdream.viewmodels.BatteryReferenceViewModel.getValue(BatteryReferenceViewModel.java:53)
                                                                                                    	at com.firebirdberlin.nightdream.viewmodels.BatteryReferenceViewModel.updateIfNecessary(BatteryReferenceViewModel.java:22)
                                                                                                    	at com.firebirdberlin.nightdream.services.CheckChargingStateJob.doWork(CheckChargingStateJob.java:52)
                                                                                                    	at androidx.work.Worker$1.run(Worker.java:86)
                                                                                                    	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137) 
                                                                                                    	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637) 
                                                                                                    	at java.lang.Thread.run(Thread.java:1012) 