### PR TITLE
BatteryReferenceViewModel Nullpointer Bugfix

### DIFF
--- a/src/com/firebirdberlin/nightdream/viewmodels/BatteryReferenceViewModel.java
+++ b/src/com/firebirdberlin/nightdream/viewmodels/BatteryReferenceViewModel.java
@@ -36,6 +36,9 @@ public class BatteryReferenceViewModel extends ViewModel {
 
     public static void set(Context context, BatteryValue value) {
         Log.i(TAG, "setting " + (value != null ? value.toString() : "null"));
+        if (batteryValue == null) {
+            batteryValue = new MutableLiveData<>();
+        }
         batteryValue.postValue(value);
         Settings.saveBatteryReference(context, value);
     }


### PR DESCRIPTION
java.util.concurrent.ExecutionException: java.lang.NullPointerException: Attempt to invoke virtual method 'void androidx.lifecycle.MutableLiveData.postValue(java.lang.Object)' on a null object reference
                                                                                                    	at androidx.work.impl.utils.futures.AbstractFuture.getDoneValue(AbstractFuture.java:516)
                                                                                                    	at androidx.work.impl.utils.futures.AbstractFuture.get(AbstractFuture.java:475)
                                                                                                    	at androidx.work.impl.WorkerWrapper$2.run(WorkerWrapper.java:311)
                                                                                                    	at androidx.work.impl.utils.SerialExecutor$Task.run(SerialExecutor.java:91)
                                                                                                    	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
                                                                                                    	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
                                                                                                    	at java.lang.Thread.run(Thread.java:1012)
                                                                                                    Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'void androidx.lifecycle.MutableLiveData.postValue(java.lang.Object)' on a null object reference
                                                                                                    	at com.firebirdberlin.nightdream.viewmodels.BatteryReferenceViewModel.set(BatteryReferenceViewModel.java:39)
                                                                                                    	at com.firebirdberlin.nightdream.viewmodels.BatteryReferenceViewModel.updateIfNecessary(BatteryReferenceViewModel.java:31)
                                                                                                    	at com.firebirdberlin.nightdream.services.CheckChargingStateJob.doWork(CheckChargingStateJob.java:52)
                                                                                                    	at androidx.work.Worker$1.run(Worker.java:86)
                                                                                                    	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137) 
                                                                                                    	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637) 
                                                                                                    	at java.lang.Thread.run(Thread.java:1012)