### PR TITLE
BugFix onSaveInstanceState Error in PreferencesActivity

### DIFF
--- a/src/com/firebirdberlin/nightdream/PreferencesActivity.java
+++ b/src/com/firebirdberlin/nightdream/PreferencesActivity.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
-import android.os.Handler;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -15,15 +14,12 @@ import androidx.fragment.app.FragmentTransaction;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 
-import java.util.List;
-
 public class PreferencesActivity extends BillingHelperActivity
         implements PreferenceFragmentCompat.OnPreferenceStartFragmentCallback {
 
     public static final String TAG = "PreferencesActivity";
     PreferencesFragment fragment = new PreferencesFragment();
     PreferencesFragment fragment2 = null;
-    Handler handler = new Handler();
     String rootKey = "";
 
     public static void start(Context context) {
@@ -34,7 +30,20 @@ public class PreferencesActivity extends BillingHelperActivity
     @Override
     protected void onPause() {
         super.onPause();
-        handler.removeCallbacks(init);
+        Log.d(TAG, "onPause()");
+    }
+
+    @Override
+    protected void onResumeFragments() {
+        super.onResumeFragments();
+        Log.d(TAG, "onResumeFragments()");
+        initFragment();
+    }
+
+    @Override
+    protected void onPostResume() {
+        super.onPostResume();
+        Log.d(TAG, "onPostResume()");
     }
 
     @Override
@@ -49,11 +58,7 @@ public class PreferencesActivity extends BillingHelperActivity
     public void onResume() {
         super.onResume();
         Log.d(TAG, "onResume");
-        handler.removeCallbacks(init);
-        handler.postDelayed(init, 300);
     }
-
-    private final Runnable init = () -> initFragment();
 
     private void removeFragment(Fragment removeFragment) {
         Log.d(TAG, "removeFragment()");
@@ -62,14 +67,13 @@ public class PreferencesActivity extends BillingHelperActivity
             Log.d(TAG, "removeFragment() isStateSaved");
             if (removeFragment != null) {
                 Log.d(TAG, "removeFragment() removed");
-                fragmentManager.beginTransaction().remove(removeFragment).commitAllowingStateLoss();
+                fragmentManager.beginTransaction().remove(removeFragment).commit();
             }
         }
     }
 
     public void initFragment() {
         Log.i(TAG, "initFragment()");
-        handler.removeCallbacks(init);
         FragmentManager fm = getSupportFragmentManager();
 
         FragmentTransaction fT = fm.beginTransaction();
@@ -103,15 +107,16 @@ public class PreferencesActivity extends BillingHelperActivity
             fT.replace(R.id.right, fragment);
             fT.replace(R.id.details, fragment2);
         }
+        Log.d(TAG, "Fragment Transaction Commit");
         fT.commit();
         fm.executePendingTransactions();
     }
 
     @Override
     public void onConfigurationChanged(@NonNull Configuration newConfig) {
+        Log.d(TAG, "onConfigurationChanged()");
         super.onConfigurationChanged(newConfig);
-        handler.removeCallbacks(init);
-        handler.post(init);
+        initFragment();
     }
 
     @Override
@@ -126,9 +131,6 @@ public class PreferencesActivity extends BillingHelperActivity
                 isPurchased(BillingHelperActivity.ITEM_WEATHER_DATA),
                 isPurchased(BillingHelperActivity.ITEM_DONATION)
         );
-
-        handler.removeCallbacks(init);
-        handler.postDelayed(init, 200);
     }
 
     @Override
@@ -143,8 +145,6 @@ public class PreferencesActivity extends BillingHelperActivity
                         isPurchased(BillingHelperActivity.ITEM_WEATHER_DATA),
                         isPurchased(BillingHelperActivity.ITEM_DONATION)
                 );
-                handler.removeCallbacks(init);
-                handler.postDelayed(init, 200);
             }
         );
         }
@@ -198,6 +198,23 @@ public class PreferencesActivity extends BillingHelperActivity
         onBackPressed();
         return true;
     }
+    @Override
+    public void onSaveInstanceState(Bundle savedInstanceState) {
+        super.onSaveInstanceState(savedInstanceState);
+        // Save UI state changes to the savedInstanceState.
+        // This bundle will be passed to onCreate if the process is
+        // killed and restarted.
+        Log.d(TAG, "onSaveInstanceState()");
+    }
+
+    @Override
+    public void onRestoreInstanceState(Bundle savedInstanceState) {
+        super.onRestoreInstanceState(savedInstanceState);
+        // Restore UI state from the savedInstanceState.
+        // This bundle has also been passed to onCreate.
+        Log.d(TAG, "onRestoreInstanceState");
+    }
+
 
     @Override
     public boolean onPreferenceStartFragment(PreferenceFragmentCompat caller, Preference pref) {

--- a/src/com/firebirdberlin/nightdream/PreferencesFragment.java
+++ b/src/com/firebirdberlin/nightdream/PreferencesFragment.java
@@ -226,10 +226,10 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
     private final ActivityResultLauncher<String> readExternalStoragePermission = registerForActivityResult(
             new ActivityResultContracts.RequestPermission(), result -> {
                 if (result) {
-                    Log.e(TAG, "readeExternalStoragePermission: PERMISSION GRANTED");
+                    Log.d(TAG, "readExternalStoragePermission: PERMISSION GRANTED");
                     selectBackgroundImage();
                 } else {
-                    Log.e(TAG, "readeExternalStoragePermission: PERMISSION DENIED");
+                    Log.d(TAG, "readExternalStoragePermission: PERMISSION DENIED");
                     Toast.makeText(getActivity(), "Permission denied !", Toast.LENGTH_LONG).show();
                 }
             });


### PR DESCRIPTION
https://medium.com/mobile-app-development-publication/handling-illegalstateexception-can-not-perform-this-action-after-onsaveinstancestate-d4ee8b630066

https://medium.com/degoo/demystifying-androids-fragmenttransaction-and-solving-can-not-perform-this-action-after-3d45004aa22f

https://www.androiddesignpatterns.com/2013/08/fragment-transaction-commit-state-loss.html

java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
at androidx.fragment.app.FragmentManager.checkStateLoss(FragmentManager.java:1601)
at androidx.fragment.app.FragmentManager.enqueueAction(FragmentManager.java:1641)
at androidx.fragment.app.BackStackRecord.commitInternal(BackStackRecord.java:341)
at androidx.fragment.app.BackStackRecord.commit(BackStackRecord.java:306)
at com.firebirdberlin.nightdream.PreferencesActivity.initFragment(PreferencesActivity.java:106)
at com.firebirdberlin.nightdream.PreferencesActivity.lambda$new$0$com-firebirdberlin-nightdream-PreferencesActivity(PreferencesActivity.java:56)
at com.firebirdberlin.nightdream.PreferencesActivity$$ExternalSyntheticLambda1.run(Unknown Source:2)
at android.os.Handler.handleCallback(Handler.java:873)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loop(Looper.java:205)
at android.app.ActivityThread.main(ActivityThread.java:6991)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:884)
