### PR TITLE
Fix for WorkManager not Initialized

### DIFF
--- a/src/com/firebirdberlin/nightdream/services/CheckChargingStateJob.java
+++ b/src/com/firebirdberlin/nightdream/services/CheckChargingStateJob.java
@@ -1,13 +1,10 @@
 package com.firebirdberlin.nightdream.services;
 
 import android.content.Context;
-import android.media.Ringtone;
-import android.media.RingtoneManager;
-import android.net.Uri;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
-import androidx.work.OneTimeWorkRequest;
+import androidx.work.Configuration;
 import androidx.work.PeriodicWorkRequest;
 import androidx.work.WorkManager;
 import androidx.work.Worker;
@@ -32,7 +29,21 @@ public class CheckChargingStateJob extends Worker {
                         30, TimeUnit.MINUTES
                 ).addTag(TAG).build();
 
+        if(!isInitialized()){
+            WorkManager.initialize(context, new Configuration.Builder().build());
+        }
+
         WorkManager.getInstance(context).enqueue(request);
+    }
+
+    /**
+     * Provides a way to check if {@link WorkManager} is initialized in this process.
+     * https://android-review.googlesource.com/c/platform/frameworks/support/+/1941186
+     * ToDo use Workmanager.isInitialized with Ver 2.8.0
+     */
+    @SuppressWarnings("deprecation")
+    private static boolean isInitialized(){
+        return WorkManager.getInstance() != null;
     }
 
    public static void cancel(Context context) {


### PR DESCRIPTION
Exception java.lang.RuntimeException:
  at android.app.ActivityThread.performPauseActivityIfNeeded (ActivityThread.java:5064)
  at android.app.ActivityThread.performPauseActivity (ActivityThread.java:5015)
  at android.app.ActivityThread.handlePauseActivity (ActivityThread.java:4967)
  at android.app.servertransaction.PauseActivityItem.execute (PauseActivityItem.java:48)
  at android.app.servertransaction.ActivityTransactionItem.execute (ActivityTransactionItem.java:45)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleState (TransactionExecutor.java:176)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:97)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2307)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loopOnce (Looper.java:201)
  at android.os.Looper.loop (Looper.java:288)
  at android.app.ActivityThread.main (ActivityThread.java:7872)
  at java.lang.reflect.Method.invoke (Method.java)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:548)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:936)
Caused by java.lang.IllegalStateException: WorkManager is not initialized properly.  You have explicitly disabled WorkManagerInitializer in your manifest, have not manually called WorkManager#initialize at this point, and your Application does not implement Configuration.Provider.
  at androidx.work.impl.WorkManagerImpl.getInstance (WorkManagerImpl.java)
  at androidx.work.WorkManager.getInstance (WorkManager.java)
  at com.firebirdberlin.nightdream.services.CheckChargingStateJob.cancel (CheckChargingStateJob.java)
  at com.firebirdberlin.nightdream.services.CheckChargingStateJob.schedule (CheckChargingStateJob.java)
  at com.firebirdberlin.nightdream.NightDreamActivity.onPause (NightDreamActivity.java)
  at android.app.Activity.performPause (Activity.java:8481)
  at android.app.Instrumentation.callActivityOnPause (Instrumentation.java:1618)
  at android.app.ActivityThread.performPauseActivityIfNeeded (ActivityThread.java:5054)