### PR TITLE
BugFix mediaControl

### DIFF
--- a/src/com/firebirdberlin/nightdream/NightDreamActivity.java
+++ b/src/com/firebirdberlin/nightdream/NightDreamActivity.java
@@ -865,12 +865,19 @@ public class NightDreamActivity extends BillingHelperActivity
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
+        Log.d(TAG, "onConfigurationChanged()");
         int diff = newConfig.diff(prevConfig);
         if ((nightDreamUI != null) && (diff != 0)) {
             nightDreamUI.onConfigurationChanged(newConfig);
         }
         prevConfig = new Configuration(newConfig);
     }
+
+    public void mediaControlChanged() {
+        Log.d(TAG, "mediaControlChanged()");
+        nightDreamUI.onConfigurationChanged(this.getResources().getConfiguration());
+    }
+
 
     private void setMode(int new_mode) {
         nightDreamUI.setMode(new_mode, last_ambient);

--- a/src/com/firebirdberlin/nightdream/NotificationReceiver.java
+++ b/src/com/firebirdberlin/nightdream/NotificationReceiver.java
@@ -213,7 +213,7 @@ public class NotificationReceiver extends BroadcastReceiver {
 
         View clockLayout = contentView.findViewById(R.id.clockLayout);
         clockLayout.postDelayed(
-                () -> activity.onConfigurationChanged(activity.getResources().getConfiguration()),
+                () -> activity.mediaControlChanged(),
                 500
         );
     }


### PR DESCRIPTION
NotificationReceiver.java 
_clockLayout.postDelayed(
                () -> activity.onConfigurationChanged(activity.getResources().getConfiguration()),
                500
        );_

without effect due to

    public void onConfigurationChanged(Configuration newConfig) {
        super.onConfigurationChanged(newConfig);
        Log.d(TAG, "onConfigurationChanged()");
        int diff = newConfig.diff(prevConfig);
        _if ((nightDreamUI != null) && (diff != 0)) {
            nightDreamUI.onConfigurationChanged(newConfig);
        }_
        prevConfig = new Configuration(newConfig);
    }