### PR TITLE
Alarmmanager canScheduleExactAlarms

### DIFF
--- a/src/com/firebirdberlin/nightdream/receivers/PowerConnectionReceiver.java
+++ b/src/com/firebirdberlin/nightdream/receivers/PowerConnectionReceiver.java
@@ -29,7 +29,7 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 
 public class PowerConnectionReceiver extends BroadcastReceiver {
-    private static String TAG = "NightDream.PowerConnectionReceiver";
+    private static final String TAG = "NightDream:PwrConnecRvr";
     private static int PENDING_INTENT_START_APP = 0;
 
     public static PowerConnectionReceiver register(Context ctx) {
@@ -79,6 +79,7 @@ public class PowerConnectionReceiver extends BroadcastReceiver {
     }
 
     static public void schedule(Context context) {
+        Log.d(TAG, "ppt schedule()");
         Intent alarmIntent = new Intent(context, PowerConnectionReceiver.class);
         PendingIntent pendingIntent = Utility.getImmutableBroadcast(
                 context, PENDING_INTENT_START_APP, alarmIntent
@@ -86,7 +87,7 @@ public class PowerConnectionReceiver extends BroadcastReceiver {
 
         Settings settings = new Settings(context);
         if (settings.scheduledAutoStartEnabled) {
-            // The autostart feature is replaced by a new version which has a seperate setting
+            // The autostart feature is replaced by a new version which has a separate setting
             // in the preferences. Thus, the old autostart is deactivated when the new one is
             // active.
             return;
@@ -96,6 +97,12 @@ public class PowerConnectionReceiver extends BroadcastReceiver {
         AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
         alarmManager.cancel(pendingIntent);
         if (Build.VERSION.SDK_INT >= 19) {
+            if ( Build.VERSION.SDK_INT >= 31 && !alarmManager.canScheduleExactAlarms())
+            {
+               // context.startActivity(new Intent(android.provider.Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM));
+                return;
+            }
+
             alarmManager.setExact(AlarmManager.RTC_WAKEUP, start.getTimeInMillis(), pendingIntent);
         } else {
             alarmManager.set(AlarmManager.RTC_WAKEUP, start.getTimeInMillis(), pendingIntent);

--- a/src/com/firebirdberlin/nightdream/receivers/ScheduledAutoStartReceiver.java
+++ b/src/com/firebirdberlin/nightdream/receivers/ScheduledAutoStartReceiver.java
@@ -91,6 +91,11 @@ public class ScheduledAutoStartReceiver extends BroadcastReceiver {
         AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
         alarmManager.cancel(pendingIntent);
         if (Build.VERSION.SDK_INT >= 19) {
+            if ( Build.VERSION.SDK_INT >= 31 && !alarmManager.canScheduleExactAlarms())
+            {
+               // context.startActivity(new Intent(android.provider.Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM));
+                return;
+            }
             alarmManager.setExact(AlarmManager.RTC_WAKEUP, start.getTimeInMillis(), pendingIntent);
         } else {
             alarmManager.set(AlarmManager.RTC_WAKEUP, start.getTimeInMillis(), pendingIntent);

--- a/src/com/firebirdberlin/nightdream/receivers/WakeUpReceiver.java
+++ b/src/com/firebirdberlin/nightdream/receivers/WakeUpReceiver.java
@@ -134,6 +134,11 @@ public class WakeUpReceiver extends BroadcastReceiver {
         pI = WakeUpReceiver.getPendingIntent(context, nextAlarmEntry, PendingIntent.FLAG_CANCEL_CURRENT);
         long nextAlarmTime = nextAlarmEntry.getMillis();
         if (Build.VERSION.SDK_INT >= 21) {
+            if ( Build.VERSION.SDK_INT >= 31 && !am.canScheduleExactAlarms())
+            {
+                // context.startActivity(new Intent(android.provider.Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM));
+                return;
+            }
             PendingIntent pi = getShowIntent(context);
             AlarmManager.AlarmClockInfo info = new AlarmManager.AlarmClockInfo(nextAlarmTime, pi);
             am.setAlarmClock(info, pI);


### PR DESCRIPTION
check if the permission was granted on api >= 31

https://developer.android.com/training/scheduling/alarms#using-schedule-exact-permission

java.lang.RuntimeException: Unable to pause activity {com.firebirdberlin.nightdream/com.firebirdberlin.nightdream.NightDreamActivity}: java.lang.SecurityException: Caller com.firebirdberlin.nightdream needs to hold android.permission.SCHEDULE_EXACT_ALARM or android.permission.USE_EXACT_ALARM to set exact alarms.
                                                                                                    	at android.app.ActivityThread.performPauseActivityIfNeeded(ActivityThread.java:5704)
                                                                                                    	at android.app.ActivityThread.performPauseActivity(ActivityThread.java:5655)
                                                                                                    	at android.app.ActivityThread.handleRelaunchActivityInner(ActivityThread.java:6438)
                                                                                                    	at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:6342)
                                                                                                    	at android.app.servertransaction.ActivityRelaunchItem.execute(ActivityRelaunchItem.java:71)
                                                                                                    	at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45)
                                                                                                    	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
                                                                                                    	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
                                                                                                    	at android.app.ClientTransactionHandler.executeTransaction(ClientTransactionHandler.java:65)
                                                                                                    	at android.app.ActivityThread.handleRelaunchActivityLocally(ActivityThread.java:6427)
                                                                                                    	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2581)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:106)
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:226)
                                                                                                    	at android.os.Looper.loop(Looper.java:313)
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:8741)
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
                                                                                                    Caused by: java.lang.SecurityException: Caller com.firebirdberlin.nightdream needs to hold android.permission.SCHEDULE_EXACT_ALARM or android.permission.USE_EXACT_ALARM to set exact alarms.
                                                                                                    	at android.os.Parcel.createExceptionOrNull(Parcel.java:3023)
                                                                                                    	at android.os.Parcel.createException(Parcel.java:3007)
                                                                                                    	at android.os.Parcel.readException(Parcel.java:2990)
                                                                                                    	at android.os.Parcel.readException(Parcel.java:2932)
                                                                                                    	at android.app.IAlarmManager$Stub$Proxy.set(IAlarmManager.java:346)
                                                                                                    	at android.app.AlarmManager.setImpl(AlarmManager.java:1000)
                                                                                                    	at android.app.AlarmManager.setImpl(AlarmManager.java:960)
                                                                                                    	at android.app.AlarmManager.setExact(AlarmManager.java:758)
                                                                                                    	at com.firebirdberlin.nightdream.receivers.ScheduledAutoStartReceiver.schedule(ScheduledAutoStartReceiver.java:94)
                                                                                                    	at com.firebirdberlin.nightdream.NightDreamActivity.onPause(NightDreamActivity.java:637)
                                                                                                    	at android.app.Activity.performPause(Activity.java:8765)
                                                                                                    	at android.app.Instrumentation.callActivityOnPause(Instrumentation.java:1585)
                                                                                                    	at android.app.ActivityThread.performPauseActivityIfNeeded(ActivityThread.java:5694)
                                                                                                    	at android.app.ActivityThread.performPauseActivity(ActivityThread.java:5655) 
                                                                                                    	at android.app.ActivityThread.handleRelaunchActivityInner(ActivityThread.java:6438) 
                                                                                                    	at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:6342) 
                                                                                                    	at android.app.servertransaction.ActivityRelaunchItem.execute(ActivityRelaunchItem.java:71) 
                                                                                                    	at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45) 
                                                                                                    	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135) 
                                                                                                    	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95) 
                                                                                                    	at android.app.ClientTransactionHandler.executeTransaction(ClientTransactionHandler.java:65) 
                                                                                                    	at android.app.ActivityThread.handleRelaunchActivityLocally(ActivityThread.java:6427) 
                                                                                                    	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2581) 
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:106) 
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:226) 
                                                                                                    	at android.os.Looper.loop(Looper.java:313) 
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:8741) 
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method) 
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571) 
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067) 
                                                                                                    Caused by: android.os.RemoteException: Remote stack trace:
                                                                                                    	at com.android.server.alarm.AlarmManagerService$5.set(AlarmManagerService.java:3393)
                                                                                                    	at android.app.IAlarmManager$Stub.onTransact(IAlarmManager.java:199)
                                                                                                    	at android.os.Binder.execTransactInternal(Binder.java:1316)
                                                                                                    	at android.os.Binder.execTransact(Binder.java:1280)

java.lang.SecurityException: Caller com.firebirdberlin.nightdream needs to hold android.permission.SCHEDULE_EXACT_ALARM or android.permission.USE_EXACT_ALARM to set exact alarms.
                                                                                                    	at android.os.Parcel.createExceptionOrNull(Parcel.java:3023)
                                                                                                    	at android.os.Parcel.createException(Parcel.java:3007)
                                                                                                    	at android.os.Parcel.readException(Parcel.java:2990)
                                                                                                    	at android.os.Parcel.readException(Parcel.java:2932)
                                                                                                    	at android.app.IAlarmManager$Stub$Proxy.set(IAlarmManager.java:346)
                                                                                                    	at android.app.AlarmManager.setImpl(AlarmManager.java:1000)
                                                                                                    	at android.app.AlarmManager.setImpl(AlarmManager.java:960)
                                                                                                    	at android.app.AlarmManager.setAlarmClock(AlarmManager.java:861)
                                                                                                    	at com.firebirdberlin.nightdream.receivers.WakeUpReceiver.setAlarm(WakeUpReceiver.java:139)
                                                                                                    	at com.firebirdberlin.nightdream.receivers.WakeUpReceiver.schedule(WakeUpReceiver.java:50)
                                                                                                    	at com.firebirdberlin.nightdream.services.SqliteIntentService.scheduleAlarm(SqliteIntentService.java:77)
                                                                                                    	at com.firebirdberlin.nightdream.NightDreamActivity.onWindowFocusChanged(NightDreamActivity.java:514)
                                                                                                    	at androidx.appcompat.view.WindowCallbackWrapper.onWindowFocusChanged(WindowCallbackWrapper.java:124)
                                                                                                    	at com.android.internal.policy.DecorView.onWindowFocusChanged(DecorView.java:2686)
                                                                                                    	at android.view.View.dispatchWindowFocusChanged(View.java:15806)
                                                                                                    	at android.view.ViewGroup.dispatchWindowFocusChanged(ViewGroup.java:1512)
                                                                                                    	at android.view.ViewRootImpl.handleWindowFocusChanged(ViewRootImpl.java:4548)
                                                                                                    	at android.view.ViewRootImpl.-$$Nest$mhandleWindowFocusChanged(Unknown Source:0)
                                                                                                    	at android.view.ViewRootImpl$ViewRootHandler.handleMessageImpl(ViewRootImpl.java:6582)
                                                                                                    	at android.view.ViewRootImpl$ViewRootHandler.handleMessage(ViewRootImpl.java:6491)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:106)
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:226)
                                                                                                    	at android.os.Looper.loop(Looper.java:313)
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:8741)
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
                                                                                                    Caused by: android.os.RemoteException: Remote stack trace:
                                                                                                    	at com.android.server.alarm.AlarmManagerService$5.set(AlarmManagerService.java:3393)
                                                                                                    	at android.app.IAlarmManager$Stub.onTransact(IAlarmManager.java:199)
                                                                                                    	at android.os.Binder.execTransactInternal(Binder.java:1316)
                                                                                                    	at android.os.Binder.execTransact(Binder.java:1280)