### PR TITLE
Bugfix for clock layout digital 3 on some devices

### DIFF
--- a/res/layout/weather_layout.xml
+++ b/res/layout/weather_layout.xml
@@ -34,7 +34,7 @@
 
         </LinearLayout>
 
-        <TextView
+        <com.firebirdberlin.nightdream.ui.AutoAdjustTextView
             android:id="@+id/temperatureText"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -85,7 +85,7 @@
             tools:ignore="RtlSymmetry" />
 
 
-        <TextView
+        <com.firebirdberlin.nightdream.ui.AutoAdjustTextView
             android:ellipsize="none"
             android:id="@+id/locationText"
             android:layout_height="wrap_content"

--- a/src/com/firebirdberlin/nightdream/ui/WeatherLayout.java
+++ b/src/com/firebirdberlin/nightdream/ui/WeatherLayout.java
@@ -40,8 +40,8 @@ public class WeatherLayout extends LinearLayout {
     private TextView iconText = null;
     private ImageView iconImage = null;
     private TextView iconWind = null;
-    private TextView temperatureText = null;
-    private TextView locationText = null;
+    private AutoAdjustTextView temperatureText = null;
+    private AutoAdjustTextView locationText = null;
     private TextView windText = null;
     private LinearLayout container = null;
     private boolean showApparentTemperature = false;
@@ -299,8 +299,21 @@ public class WeatherLayout extends LinearLayout {
                 }
             }
 
-            temperatureText.setText(entry.formatTemperatureText(temperatureUnit, showApparentTemperature));
-            locationText.setText(entry.cityName);
+            if (temperatureText != null) {
+                temperatureText.setMaxWidth(maxWidth-maxHeight-15); //-15 for padding
+                float textSize = (float) Utility.pixelsToDp(context, maxFontSizePx);
+                temperatureText.setMaxFontSizesInSp(10.f, textSize);
+                temperatureText.setText(entry.cityName);
+                temperatureText.setText(entry.formatTemperatureText(temperatureUnit, showApparentTemperature));
+            }
+
+            if (locationText != null) {
+                locationText.setMaxWidth(maxWidth);
+                float textSize = (float) Utility.pixelsToDp(context, maxFontSizePx);
+                locationText.setMaxFontSizesInSp(10.f, textSize);
+                locationText.setText(entry.cityName);
+            }
+
             iconWind.setText("F");
             iconWindDirection.setDirection(entry.windDirection);
             windText.setText(entry.formatWindText(speedUnit));
@@ -327,13 +340,16 @@ public class WeatherLayout extends LinearLayout {
         iconText.setTextSize(unit, iconSizeFactor * size);
         iconWind.setTextSize(unit, iconSizeFactor * size);
         windText.setTextSize(unit, size);
-        temperatureText.setTextSize(unit, size);
-        locationText.setTextSize(unit, size);
+ //       temperatureText.setTextSize(unit, size);
+//        locationText.setTextSize(unit, size);
         iconImage.getLayoutParams().height = temperatureText.getHeight();
         iconImage.getLayoutParams().width = temperatureText.getHeight();
 
         iconImage.getLayoutParams().height = getIconHeight();
         iconImage.getLayoutParams().width = getIconHeight();
+
+        iconImage.getLayoutParams().height = maxHeight;
+        iconImage.getLayoutParams().width = maxHeight;
 
         invalidate();
     }


### PR DESCRIPTION
Problem with long city names (Monheim am Rhein)
![Screenshot_20230320-190749](https://user-images.githubusercontent.com/68911754/226433117-ea97f4d9-fd19-4a99-a733-0f4e21a2fcd3.png)

Problem with temperature text
![Screenshot_20230320-190808](https://user-images.githubusercontent.com/68911754/226433157-f59055cb-08e4-4a39-8dc1-e5497ff78803.png)

Bugfixed:
![Screenshot_20230320-190359](https://user-images.githubusercontent.com/68911754/226433185-4828d033-b1a3-42bd-b61a-8a364b3586a2.png)

Testet with all layout on Android 9 + 13
