### PR TITLE
Fixed a NullPointerException

### DIFF
--- a/app/src/main/java/com/firebirdberlin/nightdream/Utility.java
+++ b/app/src/main/java/com/firebirdberlin/nightdream/Utility.java
@@ -135,11 +135,18 @@ public class Utility {
 
     public static void deleteDirectory(File fileOrDirectory) {
         if (fileOrDirectory == null) return;
-        if (fileOrDirectory.isDirectory())
-            for (File child : fileOrDirectory.listFiles()) {
-                Utility.deleteDirectory(child);
+        File[] files = fileOrDirectory.listFiles();
+        if(files != null) {
+            for (File file : files) {
+                Utility.deleteDirectory(file);
             }
-        fileOrDirectory.delete();
+        }
+
+        if (fileOrDirectory.delete()){
+            Log.d("deleteDirectory", "File or directory deleted:"+fileOrDirectory.getName());
+        } else {
+            Log.e("deleteDirectory", "File or Directory not deleted:"+fileOrDirectory.getName());
+        }
     }
 
     public static boolean copyToDirectory(Context context, Uri srcUri, File directory, String name) {


### PR DESCRIPTION
Warning “Dereference of ‘fileOrDirectory.listFiles()’ may produce ‘java.lang.NullPointerException’”. 

listFiles() search the given directory for files at every call. 
The directory could be empty when the a second call executes, even when it was not at the time the first call.

listFiles() will return null if the given path is not a directory

Better solution in PR.